### PR TITLE
test: add pool rejection test

### DIFF
--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -33,4 +33,22 @@ describe(Support.getTestDialectTeaser('Pooling'), function() {
     return expect(this.testInstance.authenticate())
       .to.eventually.be.rejectedWith('ResourceRequest timed out');
   });
+  
+  it('should not result in unhandled promise rejection when unable to acquire connection', () => {
+    this.testInstance = new Sequelize('localhost', 'ffd', 'dfdf', {
+      dialect,
+      databaseVersion: '1.2.3',
+      pool: {
+        acquire: 1000,
+        max: 1
+      }
+    });
+
+    this.sinon.stub(this.testInstance.connectionManager, '_connect')
+      .returns(new Sequelize.Promise(() => {}));
+
+    return expect(this.testInstance.transaction()
+      .then(() => this.testInstance.transaction()))
+      .to.eventually.be.rejectedWith('ResourceRequest timed out');
+  });
 });


### PR DESCRIPTION
adds a test to validate the change of PR sequelize/sequelize#9051

this essentially creates a pool with max instances set to 1 and then tries to create two unmanaged transactions.
without the proposed fix, this will result in an unhandled promise rejection.
with the fix, the second call to `sequelize.transaction` is being rejected with the pool time out error (expected behaviour)